### PR TITLE
Upgrading sdl2 and glium versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Version 0.11 (2016-04-11)
+- Changed glium dependency to version `0.13.5`
+- Changed SDL2 dependency to version `0.17` fixing use of SdlResult
+
 ## Version 0.10 (2016-01-26)
 - Changed glium dependency to version `0.13`
 - Changed SDL2 dependency to version `0.13`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium_sdl2"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Dan Spencer <dan@atomicpotato.net>"]
 license = "MIT/Apache-2.0"
 keywords = ["graphics", "gamedev", "glium", "sdl", "opengl"]
@@ -9,10 +9,10 @@ repository = "https://github.com/nukep/glium-sdl2/"
 description = "An SDL2 backend for Glium - a high-level OpenGL wrapper for the Rust language."
 
 [dependencies]
-sdl2 = "0.13"
+sdl2 = "0.17"
 
 [dependencies.glium]
-version = "0.13"
+version = "0.13.5"
 # Do not enable any features by default, as to not bring in unwanted dependencies
 # (Cargo seems to apply a "union" of requested features across projects for any given dependency).
 # Instead, Let the library user define which features they want.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,6 @@ use glium::debug;
 use glium::backend::{Backend, Context, Facade};
 use sdl2::VideoSubsystem;
 use sdl2::video::{Window, WindowRef, WindowBuildError};
-use std::io;
-use std::cmp::Ordering;
 
 pub type Display = SDL2Facade;
 


### PR DESCRIPTION
This fixes issue #16 

The upgrade for sdl2 was a bit more involved since SdlResult seems to have vanished. The most sensible thing I could think of is adding a GliumSdl2Error but I am bit new at rust so maybe this isn't the right way to do this.

I tried the examples one appears to not run on my computer the other seems to work now.
