### PR TITLE
Relax version bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/nukep/glium-sdl2/"
 description = "An SDL2 backend for Glium - a high-level OpenGL wrapper for the Rust language."
 
 [dependencies]
-sdl2 = "0.19"
+sdl2 = "*"
 
 [dependencies.glium]
-version = "0.14"
+version = "*"
 # Do not enable any features by default, as to not bring in unwanted dependencies
 # (Cargo seems to apply a "union" of requested features across projects for any given dependency).
 # Instead, Let the library user define which features they want.
@@ -20,6 +20,6 @@ features = []
 default-features = false
 
 [dev-dependencies]
-clock_ticks = "0.1.0"
-genmesh = "0.4"
-obj = { version = "0.5", features = ["usegenmesh"] }
+clock_ticks = "*"
+genmesh = "*"
+obj = { version = "*", features = ["usegenmesh"] }


### PR DESCRIPTION
Hello and thanks for writing the glium-sdl2.

I tried to build it but I had an issue where the version bounds were too strict. I changed them to "_" and now everything is working. I've been using for a while now without any issues. I'll let you decide if you want to use "_" or something stricter, but either way the version bounds need a bump. This PR is for bounds of "*".
