### PR TITLE
Latest glium + sdl2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/nukep/glium-sdl2/"
 description = "An SDL2 backend for Glium - a high-level OpenGL wrapper for the Rust language."
 
 [dependencies]
-sdl2 = "0.29.1"
+sdl2 = "0.30.0"
 
 [dependencies.glium]
-version = "0.16"
+version = "0.16.0"
 # Do not enable any features by default, as to not bring in unwanted dependencies
 # (Cargo seems to apply a "union" of requested features across projects for any given dependency).
 # Instead, Let the library user define which features they want.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "An SDL2 backend for Glium - a high-level OpenGL wrapper for the R
 sdl2 = "0.27"
 
 [dependencies.glium]
-version = "0.15"
+version = "0.16"
 # Do not enable any features by default, as to not bring in unwanted dependencies
 # (Cargo seems to apply a "union" of requested features across projects for any given dependency).
 # Instead, Let the library user define which features they want.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/nukep/glium-sdl2/"
 description = "An SDL2 backend for Glium - a high-level OpenGL wrapper for the Rust language."
 
 [dependencies]
-sdl2 = "0.27"
+sdl2 = "0.29.1"
 
 [dependencies.glium]
 version = "0.16"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ are in heavy development and are subject to change.
 ```toml
 [dependencies]
 glium_sdl2 = "0.14"
-sdl2 = "0.27"
+sdl2 = "0.29.1"
 glium = "0.16"
 
 features = []

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ are in heavy development and are subject to change.
 
 ```toml
 [dependencies]
-glium_sdl2 = "0.13"
+glium_sdl2 = "0.14"
 sdl2 = "0.27"
-glium = "0.15"
+glium = "0.16"
 
 features = []
 default-features = false

--- a/examples/tutorial01.rs
+++ b/examples/tutorial01.rs
@@ -4,12 +4,17 @@ extern crate glium;
 extern crate glium_sdl2;
 extern crate sdl2;
 
+use sdl2::video::GLProfile;
+
 fn main() {
     use glium_sdl2::DisplayBuild;
     use glium::Surface;
 
     let sdl_context = sdl2::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
+    let gl_attr = video_subsystem.gl_attr();
+    gl_attr.set_context_profile(GLProfile::Core);
+    gl_attr.set_context_version(3, 2);
 
     let display = video_subsystem.window("Tutorial 01", 800, 600).resizable().build_glium().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ use glium::SwapBuffersError;
 use glium::debug;
 use glium::backend::{Backend, Context, Facade};
 use sdl2::VideoSubsystem;
-use sdl2::video::{Window, WindowRef, WindowBuildError};
+use sdl2::video::{Window, WindowBuildError};
 
 pub type Display = SDL2Facade;
 
@@ -129,11 +129,11 @@ impl Deref for SDL2Facade {
 }
 
 impl SDL2Facade {
-    pub fn window(&self) -> &WindowRef {
+    pub fn window(&self) -> &Window {
         self.backend.window()
     }
 
-    pub fn window_mut(&mut self) -> &mut WindowRef {
+    pub fn window_mut(&mut self) -> &mut Window {
         self.backend.window_mut()
     }
 
@@ -236,13 +236,13 @@ impl SDL2WindowBackend {
         window.subsystem()
     }
 
-    fn window(&self) -> &WindowRef {
+    fn window(&self) -> &Window {
         let ptr = self.window.get();
         let window: &Window = unsafe { mem::transmute(ptr) };
         window
     }
 
-    fn window_mut(&self) -> &mut WindowRef {
+    fn window_mut(&self) -> &mut Window {
         let ptr = self.window.get();
         let window: &mut Window = unsafe { mem::transmute(ptr) };
         window


### PR DESCRIPTION
This PR updates glium-sdl2 to the latest version of SDL2. This PR includes the changes from #24 and therefore supersedes it. Instead of raising a new PR every version update, I'll just continue adding to this one.

Notes from #24:

> This PR updates glium-sdl2 to the latest version of SDL2. This PR includes the changes from #23 and therefore supersedes it.
> 
> Notes from #23:
> 
> > This PR updates glium-sdl2 to the latest version of glium.
> > 
> > I updated the README in anticipation of the next version of glium-sdl2 being 0.14, but I didn't update the cargo.toml in case bumping that is part of your release process.
> > 
> > The tutorial01 example crashed on MacOS because the default OpenGL version is < 3.1 so the shader fails to compile. I've explicitly set the OpenGL version to 3.1 in the example and it no longer crashes. This setting should be ok for other systems. The other examples worked fine.