### PR TITLE
Update versions and remove deprecated Rust idioms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Version 0.16 (2020-12-14)
+- Changed glium dependency to version `0.28`
+- Changed SDL2 dependency to version `0.34`
+- Update deprecated Rust idioms to remove warnings
+
 ## Version 0.15 (2017-10-19)
 - Changed glium dependency to version `0.18`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium_sdl2"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Danny Spencer <dan@atomicpotato.net>"]
 license = "MIT/Apache-2.0"
 keywords = ["graphics", "gamedev", "glium", "sdl", "opengl"]
@@ -9,10 +9,10 @@ repository = "https://github.com/nukep/glium-sdl2/"
 description = "An SDL2 backend for Glium - a high-level OpenGL wrapper for the Rust language."
 
 [dependencies]
-sdl2 = "0.30"
+sdl2 = "0.34"
 
 [dependencies.glium]
-version = "0.18"
+version = "0.28"
 # Do not enable any features by default, as to not bring in unwanted dependencies
 # (Cargo seems to apply a "union" of requested features across projects for any given dependency).
 # Instead, Let the library user define which features they want.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ are in heavy development and are subject to change.
 
 ```toml
 [dependencies]
-glium_sdl2 = "0.15"
-sdl2 = "0.30"
-glium = "0.18"
+glium_sdl2 = "0.16"
+sdl2 = "0.34"
+glium = "0.28"
 
 features = []
 default-features = false

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -80,5 +80,5 @@ pub fn load_wavefront(display: &Display, data: &[u8]) -> VertexBufferAny {
         }
     }
 
-    glium::vertex::VertexBuffer::new(display, &vertex_data).unwrap().into_vertex_buffer_any()
+    glium::vertex::VertexBuffer::new(display, &vertex_data).unwrap().into()
 }


### PR DESCRIPTION
Use recent versions for dependencies: glium 0.28 and sdl2 0.34
Replace deprecated Rust idioms (i.e. try! with ? and error handling)